### PR TITLE
[WIP] try to remove warning for cross-site cookies

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -7,7 +7,9 @@ exports.onRenderBody = ({ setPostBodyComponents }, options) => {
       id="stripe-js"
       key="gatsby-plugin-stripe"
       src="https://js.stripe.com/v3/"
-      async={options.async}
+      async={options.async},
+      SameSite: "None",
+      Secure: "Secure"
     />
   ]);
 };


### PR DESCRIPTION
Hi Nathan! (great name, btw 🤓 ),

I'm using your plugin to build out a site for an insurance company, and as you can imagine, they're pretty meticulous on their code reviews.

One warning I keep seeing in development is from Chrome:

```
A cookie associated with a cross-site resource at http://stripe.com/ was set without the `SameSite` attribute. A future release of Chrome will only deliver cookies with cross-site requests if they are set with `SameSite=None` and `Secure`. You can review cookies in developer tools under Application>Storage>Cookies and see more details at https://www.chromestatus.com/feature/5088147346030592 and https://www.chromestatus.com/feature/5633521622188032.
```

So, I thought I'd give this the good ol' college try and edit the file that populates the stripe tag. In editing the current file with this proposed change, I'm still seeing the warning. I wanted to create this WIP to check and see if you knew better where to change things. I'm happy to update this PR, but if you have any guidance on developing with the upcoming Chrome changes and removing the warning, let me know. 

Thanks for the plugin, you're awesome. 
Nate